### PR TITLE
[timing] return internal function timing

### DIFF
--- a/run.py
+++ b/run.py
@@ -172,6 +172,18 @@ def _sort_leaderboard(table):
     return sorted(table, key=lambda r: r[2])
 
 
+def duration_from_answer(answer, msec):
+    DURATION_HEADER_PREFIX = "_duration:"
+    split = str(answer).split("\n")
+    if len(split) < 2 or (not split[0].startswith(DURATION_HEADER_PREFIX)):
+        return answer, msec
+    try:
+        return "\n".join(split[1:]), float(split[0][len(DURATION_HEADER_PREFIX):])
+    except ValueError:
+        pass
+    return answer, msec
+
+
 def run_submissions_for_contest(contest_path):
     print("\n" + bcolors.MAGENTA + bcolors.BOLD + "* contest %s:" % os.path.basename(contest_path) + bcolors.ENDC)
     submissions = load_submissions_for_contest(contest_path)
@@ -199,6 +211,7 @@ def run_submissions_for_contest(contest_path):
                 answer = _run_submission(author, submission, input_content)
                 time_after = datetime.datetime.now()
                 msecs = (time_after - time_before).total_seconds() * 1000
+                answer, msecs = duration_from_answer(answer, msecs)
                 table.append([
                     "  {green}{author}{end}  ".format(green=bcolors.GREEN, author=author, end=bcolors.ENDC),
                     "  {blue}{answer}{end}  ".format(blue=bcolors.BLUE, answer=answer, end=bcolors.ENDC),

--- a/runners/wrapper.py
+++ b/runners/wrapper.py
@@ -19,8 +19,17 @@ class SubmissionWrapper(SubmissionPy):
         stdout = self.exec(input)
         try:
             lines = stdout.split('\n')[:-1]
+            duration_line = None
+            for line in lines:
+                if line.startswith("_duration:"):
+                    duration_line = line
+                    break
+            lines = [line for line in lines if not line.startswith("_duration:")]
             if len(lines) > 1:
                 print('\n'.join(lines[:-1]))
+
+            if duration_line:
+                return '\n'.join([duration_line, lines[-1]])
             return lines[-1]
         except Exception:
             return None

--- a/templates/template.c
+++ b/templates/template.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <time.h>
 
 char* run(char* s)
 {
@@ -11,6 +12,10 @@ int main(int argc, char** argv)
         printf("Missing one argument\n");
         exit(1);
     }
-    printf("%s\n", run(argv[1]));
+
+    clock_t start = clock();
+    char* answer = run(argv[1]);
+    
+    printf("_duration:%f\n%s\n", (float)( clock () - start ) * 1000.0 /  CLOCKS_PER_SEC, answer);
     return 0;
 }

--- a/templates/template.cpp
+++ b/templates/template.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <ctime>
 
 using namespace std;
 
@@ -12,6 +13,11 @@ int main(int argc, char** argv) {
         cout << "Missing one argument" << endl;
         exit(1);
     }
-    cout << run(string(argv[1])) << "\n";
+
+    clock_t start = clock();
+    auto answer = run(string(argv[1]));
+    
+    cout << "_duration:" << float( clock () - start ) * 1000.0 /  CLOCKS_PER_SEC << "\n";
+    cout << answer << "\n";
     return 0;
 }

--- a/templates/template.go
+++ b/templates/template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 )
 
 func run(s string) string {
@@ -15,5 +16,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(run(string(input)))
+	start := time.Now()
+	res := run(string(input))
+	fmt.Printf("_duration:%f\n", time.Now().Sub(start).Seconds()*1000)
+	fmt.Println(res)
 }

--- a/templates/template.js
+++ b/templates/template.js
@@ -6,4 +6,8 @@ const run = s => {
   // Your code goes here
 };
 
-console.log(run(process.argv[2]));
+let start = Date.now();
+let answer = run(process.argv[2]);
+
+console.log("_duration:" + (Date.now() - start).toString());
+console.log(answer);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -2,4 +2,9 @@ def run(s)
     # Your code goes here
 end
 
-puts run(ARGV[0])
+
+starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+answer = run(ARGV[0].lines)
+elapsed = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - starting) * 1000
+
+puts "_duration:#{elapsed}\n#{answer}"

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -7,8 +7,8 @@ fn main() {
     let elapsed = now.elapsed();
     println!(
         "_duration:{}.{}",
-        elapsed.as_secs(),
-        elapsed.subsec_millis()
+        elapsed.as_secs() * 1000 + u64::from(elapsed.subsec_millis()),
+        elapsed.subsec_micros() - (elapsed.subsec_millis() * 1000)
     );
     println!("{}", output);
 }

--- a/templates/template.rs
+++ b/templates/template.rs
@@ -1,7 +1,16 @@
 use std::env::args;
+use std::time::Instant;
 
 fn main() {
-    println!("{}", run(args().nth(1).expect("Please provide an input")))
+    let now = Instant::now();
+    let output: String = run(args().nth(1).expect("Please provide an input"));
+    let elapsed = now.elapsed();
+    println!(
+        "_duration:{}.{}",
+        elapsed.as_secs(),
+        elapsed.subsec_millis()
+    );
+    println!("{}", output);
 }
 
 fn run(input: String) -> String {


### PR DESCRIPTION
internally calculate execution time and return it as a header to the answer. 
 
 - [x] c
 - [x] c++
 - [x] go
 - [x] js
 - [x] rb
 - [x] rs
 - [ ] ~~python~~ (doesn't apply)

it's backward compatible 