### PR TITLE
[conf] avoid conflicts in go linter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "go.buildOnSave": "off",
+    "go.lintOnSave": "file",
+    "go.vetOnSave": "off"
+}


### PR DESCRIPTION
Go, C and C++ files in the same directory do not belong to the same go package