### PR TITLE
Create a symlink to workspace for golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ target/
 *.rs.bk
 # To allow to keep code but not push it because it's too slow
 *.save
+# To allow to work on gocode
+workspace
 
 # No effing test ;)
 *_test.go

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "go.buildOnSave": "off",
-    "go.lintOnSave": "file",
-    "go.vetOnSave": "off"
-}

--- a/create.py
+++ b/create.py
@@ -99,12 +99,13 @@ def create_submission(author, path, language):
 
     # Create a symlink to workspace if it is a Golang project
     if language == "go":
-        workspace_directory = "workspace" + path[1:]
-        absolute_submission_file = os.getcwd() + submission_file[1:]
-        workspace_submission_file = "workspace" + submission_file[1:]
+        workspace_directory = os.path.join("./workspace", os.path.normpath(path))
+        workspace_submission_file = os.path.join("./workspace", os.path.normpath(submission_file))
         if not os.path.exists(workspace_submission_file):
             os.makedirs(workspace_directory, mode=0o777, exist_ok=True)
-            os.symlink(absolute_submission_file, workspace_submission_file)
+            os.symlink(os.path.realpath(submission_file), workspace_submission_file)
+            # Log success
+            print(f"[+] created symlink in {workspace_submission_file}")
 
 def create_input(author, path):
     """

--- a/create.py
+++ b/create.py
@@ -97,6 +97,14 @@ def create_submission(author, path, language):
         cargo.write(f"\n[[bin]]\nname = \"{submission_name}\"\npath = \"{submission_file}\"\n")
         print("[+] added submission to Cargo.toml")
 
+    # Create a symlink to workspace if it is a Golang project
+    if language == "go":
+        workspace_directory = "workspace" + path[1:]
+        absolute_submission_file = os.getcwd() + submission_file[1:]
+        workspace_submission_file = "workspace" + submission_file[1:]
+        if not os.path.exists(workspace_submission_file):
+            os.makedirs(workspace_directory, mode=0o777, exist_ok=True)
+            os.symlink(absolute_submission_file, workspace_submission_file)
 
 def create_input(author, path):
     """


### PR DESCRIPTION
## What does this PR do ?

- Create a workspace directory with the following structure for people creating submissions in Golang : 

```
workspace
├── day-01
│   ├── part-1
│   │   └── gandem.go -> /Users/nayef.ghattas/Projects/advent-of-code-2018/day-01/part-1/gandem.go
│   └── part-2
│       └── gandem.go -> /Users/nayef.ghattas/Projects/advent-of-code-2018/day-01/part-2/gandem.go
```

- Add this directory to `.gitignore`
- Remove `vscode/settings.json`

## Who is impacted ?

People developing in Golang

## Motivation 

The actual vscode settings disable `vetOnSave` which is useful for several use cases : https://golang.org/cmd/vet/

However, `vet` will error when running in the original `day-xx/part-x` folder because of multiple main functions (one per golang submission), and cpp/c submissions (because of the cgo interface)

The proposed workaround is to develop `go` submission in the `workspace` folder which will contain symlinks to the original folder.